### PR TITLE
Feat/pomodoro timer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 .deploy
 .coverage
+.vscode
 settings.coverage.json

--- a/client/main.js
+++ b/client/main.js
@@ -1,9 +1,9 @@
 /* global document */
 
+import 'bootstrap/dist/css/bootstrap.css';
 import { Meteor } from 'meteor/meteor';
 import { render } from 'react-dom';
 import { renderRoutes } from '../imports/startup/client/routes.jsx';
-import 'bootstrap/dist/css/bootstrap.css';
 
 Meteor.startup(() => {
   render(renderRoutes(), document.getElementById('app'));

--- a/client/main.less
+++ b/client/main.less
@@ -21,6 +21,7 @@
 @import "{}/imports/ui/components/ConnectionNotification.less";
 @import "{}/imports/ui/components/ListHeader.less";
 @import "{}/imports/ui/components/ListList.less";
+@import "{}/imports/ui/components/PomoTimer.less";
 @import "{}/imports/ui/components/Loading.less";
 @import "{}/imports/ui/components/Message.less";
 @import "{}/imports/ui/components/TodoItem.less";

--- a/i18n/en.i18n.json
+++ b/i18n/en.i18n.json
@@ -19,7 +19,8 @@
       "makeListPrivate": "Make list private",
       "deleteList": "Delete list",
       "cancel": "Cancel",
-      "typeToAdd": "Type to add new tasks"
+      "typeToAdd": "Type to add new tasks",
+      "selectEstimatedPomodoros": "Estimated Pomodoros"
     },
     "listList": {
       "newList": "New List",

--- a/i18n/fr.i18n.json
+++ b/i18n/fr.i18n.json
@@ -19,7 +19,8 @@
       "makeListPrivate": "Fermer la liste au public",
       "deleteList": "Effacer la liste",
       "cancel": "Annuler",
-      "typeToAdd": "Tapez pour ajouter de nouvelles tâches"
+      "typeToAdd": "Tapez pour ajouter de nouvelles tâches",
+      "selectEstimatedPomodoros": "Estimê Pomodoros"
     },
     "listList": {
       "newList": "Nouvelle liste",

--- a/imports/api/todos/methods.js
+++ b/imports/api/todos/methods.js
@@ -102,6 +102,27 @@ export const updatePomosEstimated = new ValidatedMethod({
   },
 });
 
+export const pomosCompletedPlusPlus = new ValidatedMethod({
+  name: 'todos.pomosCompletedPlusPlus',
+  validate: new SimpleSchema({
+    todoId: { type: String },
+  }).validator(),
+  run({ todoId }) {
+    const todo = Todos.findOne(todoId);
+
+    if (!todo.editableBy(this.userId)) {
+      throw new Meteor.Error('api.todos.pomosCompletedPlusPlus.accessDenied',
+        'Cannot edit todos in a private list that is not yours');
+    }
+
+    const newNumber = todo.pomosCompleted ? todo.pomosCompleted + 1 : 1;
+
+    Todos.update(todoId, {
+      $set: { pomosCompleted: newNumber },
+    });
+  },
+});
+
 export const updatePomosCompleted = new ValidatedMethod({
   name: 'todos.updatePomosCompleted',
   validate: new SimpleSchema({

--- a/imports/api/todos/methods.js
+++ b/imports/api/todos/methods.js
@@ -82,6 +82,46 @@ export const updateText = new ValidatedMethod({
   },
 });
 
+export const updatePomosEstimated = new ValidatedMethod({
+  name: 'todos.updatePomosEstimated',
+  validate: new SimpleSchema({
+    todoId: { type: String },
+    newNumber: { type: Number },
+  }).validator(),
+  run({ todoId, newNumber }) {
+    const todo = Todos.findOne(todoId);
+
+    if (!todo.editableBy(this.userId)) {
+      throw new Meteor.Error('api.todos.updatePomosEstimated.accessDenied',
+        'Cannot edit todos in a private list that is not yours');
+    }
+
+    Todos.update(todoId, {
+      $set: { pomosEstimated: newNumber },
+    });
+  },
+});
+
+export const updatePomosCompleted = new ValidatedMethod({
+  name: 'todos.updatePomosCompleted',
+  validate: new SimpleSchema({
+    todoId: { type: String },
+    newNumber: { type: Number },
+  }).validator(),
+  run({ todoId, newNumber }) {
+    const todo = Todos.findOne(todoId);
+
+    if (!todo.editableBy(this.userId)) {
+      throw new Meteor.Error('api.todos.updatePomosCompleted.accessDenied',
+        'Cannot edit todos in a private list that is not yours');
+    }
+
+    Todos.update(todoId, {
+      $set: { pomosCompleted: newNumber },
+    });
+  },
+});
+
 export const remove = new ValidatedMethod({
   name: 'todos.remove',
   validate: new SimpleSchema({
@@ -105,6 +145,8 @@ const TODOS_METHODS = _.pluck([
   setCheckedStatus,
   updateText,
   remove,
+  updatePomosCompleted,
+  updatePomosEstimated,
 ], 'name');
 
 if (Meteor.isServer) {

--- a/imports/api/todos/methods.js
+++ b/imports/api/todos/methods.js
@@ -12,8 +12,9 @@ export const insert = new ValidatedMethod({
   validate: new SimpleSchema({
     listId: { type: String },
     text: { type: String },
+    pomosEstimated: { type: Number },
   }).validator(),
-  run({ listId, text }) {
+  run({ listId, text, pomosEstimated }) {
     const list = Lists.findOne(listId);
 
     if (list.isPrivate() && list.userId !== this.userId) {
@@ -26,6 +27,8 @@ export const insert = new ValidatedMethod({
       text,
       checked: false,
       createdAt: new Date(),
+      pomosEstimated,
+      pomosCompleted: 0,
     };
 
     Todos.insert(todo);

--- a/imports/api/todos/todos.js
+++ b/imports/api/todos/todos.js
@@ -54,6 +54,14 @@ Todos.schema = new SimpleSchema({
     type: Boolean,
     defaultValue: false,
   },
+  pomosEstimated: {
+    type: Number,
+    defaultValue: 0,
+  },
+  pomosCompleted: {
+    type: Number,
+    defaultValue: 0,
+  },
 });
 
 Todos.attachSchema(Todos.schema);
@@ -66,6 +74,8 @@ Todos.publicFields = {
   text: 1,
   createdAt: 1,
   checked: 1,
+  pomosCompleted: 1,
+  pomosEstimated: 1,
 };
 
 // TODO This factory has a name - do we have a code style for this?

--- a/imports/ui/components/ListHeader.jsx
+++ b/imports/ui/components/ListHeader.jsx
@@ -113,6 +113,7 @@ export default class ListHeader extends BaseComponent {
       }, displayError);
       input.value = '';
     }
+    this.setState({ pomosEstimated: 0});
   }
 
   focusTodoInput() {

--- a/imports/ui/components/ListHeader.jsx
+++ b/imports/ui/components/ListHeader.jsx
@@ -20,7 +20,7 @@ import {
 export default class ListHeader extends BaseComponent {
   constructor(props) {
     super(props);
-    this.state = Object.assign(this.state, { editing: false }, {pomoEstimate: 0});
+    this.state = Object.assign(this.state, { editing: false }, {pomosEstimated: 0});
     this.onListFormSubmit = this.onListFormSubmit.bind(this);
     this.onListInputKeyUp = this.onListInputKeyUp.bind(this);
     this.onListInputBlur = this.onListInputBlur.bind(this);
@@ -99,7 +99,7 @@ export default class ListHeader extends BaseComponent {
   }
 
   pomoOnChange(event) {
-    this.setState({pomoEstimate: event.target.value})
+    this.setState({pomosEstimated: event.target.value})
   }
 
   createTodo(event) {
@@ -109,7 +109,7 @@ export default class ListHeader extends BaseComponent {
       insert.call({
         listId: this.props.list._id,
         text: input.value,
-        pomoEstimate: Number(this.state.pomoEstimate),
+        pomosEstimated: Number(this.state.pomosEstimated),
       }, displayError);
       input.value = '';
     }
@@ -219,8 +219,8 @@ export default class ListHeader extends BaseComponent {
             <span className="icon-add" onClick={this.focusTodoInput} />
           </div>
           <div className="pomo-estimate-dropdown input-symbol">
-            <label className="sr-only" htmlFor="sel1">Pomo Estimate:</label>
-            <select value={this.state.pomoEstimate} onChange={this.pomoOnChange} className="form-control" id="sel1">
+            <label className="sr-only" htmlFor="sel1">Pomos Estimated:</label>
+            <select value={this.state.pomosEstimated} onChange={this.pomoOnChange} className="form-control" id="sel1">
               <option value="0" >0 {i18n.__('components.listHeader.selectEstimatedPomodoros')}</option>
               <option value="1" >1 {i18n.__('components.listHeader.selectEstimatedPomodoros')}</option>
               <option value="2" >2 {i18n.__('components.listHeader.selectEstimatedPomodoros')}</option>

--- a/imports/ui/components/ListHeader.jsx
+++ b/imports/ui/components/ListHeader.jsx
@@ -20,7 +20,7 @@ import {
 export default class ListHeader extends BaseComponent {
   constructor(props) {
     super(props);
-    this.state = Object.assign(this.state, { editing: false });
+    this.state = Object.assign(this.state, { editing: false }, {pomoEstimate: 0});
     this.onListFormSubmit = this.onListFormSubmit.bind(this);
     this.onListInputKeyUp = this.onListInputKeyUp.bind(this);
     this.onListInputBlur = this.onListInputBlur.bind(this);
@@ -32,6 +32,7 @@ export default class ListHeader extends BaseComponent {
     this.toggleListPrivacy = this.toggleListPrivacy.bind(this);
     this.createTodo = this.createTodo.bind(this);
     this.focusTodoInput = this.focusTodoInput.bind(this);
+    this.pomoOnChange = this.pomoOnChange.bind(this);
   }
 
   onListFormSubmit(event) {
@@ -97,6 +98,10 @@ export default class ListHeader extends BaseComponent {
     }
   }
 
+  pomoOnChange(event) {
+    this.setState({pomoEstimate: event.target.value})
+  }
+
   createTodo(event) {
     event.preventDefault();
     const input = this.newTodoInput;
@@ -104,6 +109,7 @@ export default class ListHeader extends BaseComponent {
       insert.call({
         listId: this.props.list._id,
         text: input.value,
+        pomoEstimate: Number(this.state.pomoEstimate),
       }, displayError);
       input.value = '';
     }
@@ -203,13 +209,26 @@ export default class ListHeader extends BaseComponent {
     return (
       <nav className="list-header">
         {editing ? this.renderEditingHeader() : this.renderDefaultHeader()}
-        <form className="todo-new input-symbol" onSubmit={this.createTodo}>
-          <input
-            type="text"
-            ref={(c) => { this.newTodoInput = c; }}
-            placeholder={i18n.__('components.listHeader.typeToAdd')}
-          />
-          <span className="icon-add" onClick={this.focusTodoInput} />
+        <form onSubmit={this.createTodo}>
+          <div className="todo-new input-symbol">
+            <input
+              type="text"
+              ref={(c) => { this.newTodoInput = c; }}
+              placeholder={i18n.__('components.listHeader.typeToAdd')}
+            />
+            <span className="icon-add" onClick={this.focusTodoInput} />
+          </div>
+          <div className="pomo-estimate-dropdown input-symbol">
+            <label className="sr-only" htmlFor="sel1">Pomo Estimate:</label>
+            <select value={this.state.pomoEstimate} onChange={this.pomoOnChange} className="form-control" id="sel1">
+              <option value="0" >0 {i18n.__('components.listHeader.selectEstimatedPomodoros')}</option>
+              <option value="1" >1 {i18n.__('components.listHeader.selectEstimatedPomodoros')}</option>
+              <option value="2" >2 {i18n.__('components.listHeader.selectEstimatedPomodoros')}</option>
+              <option value="3" >3 {i18n.__('components.listHeader.selectEstimatedPomodoros')}</option>
+              <option value="4" >4 {i18n.__('components.listHeader.selectEstimatedPomodoros')}</option>
+            </select>
+          <span className="icon-arrow-down" />
+          </div>
         </form>
       </nav>
     );

--- a/imports/ui/components/ListHeader.jsx
+++ b/imports/ui/components/ListHeader.jsx
@@ -20,7 +20,7 @@ import {
 export default class ListHeader extends BaseComponent {
   constructor(props) {
     super(props);
-    this.state = Object.assign(this.state, { editing: false }, {pomosEstimated: 0});
+    this.state = Object.assign(this.state, { editing: false }, { pomosEstimated: 0 });
     this.onListFormSubmit = this.onListFormSubmit.bind(this);
     this.onListInputKeyUp = this.onListInputKeyUp.bind(this);
     this.onListInputBlur = this.onListInputBlur.bind(this);
@@ -99,7 +99,7 @@ export default class ListHeader extends BaseComponent {
   }
 
   pomoOnChange(event) {
-    this.setState({pomosEstimated: event.target.value})
+    this.setState({ pomosEstimated: event.target.value });
   }
 
   createTodo(event) {
@@ -227,7 +227,7 @@ export default class ListHeader extends BaseComponent {
               <option value="3" >3 {i18n.__('components.listHeader.selectEstimatedPomodoros')}</option>
               <option value="4" >4 {i18n.__('components.listHeader.selectEstimatedPomodoros')}</option>
             </select>
-          <span className="icon-arrow-down" />
+            <span className="icon-arrow-down" />
           </div>
         </form>
       </nav>

--- a/imports/ui/components/ListHeader.jsx
+++ b/imports/ui/components/ListHeader.jsx
@@ -113,7 +113,7 @@ export default class ListHeader extends BaseComponent {
       }, displayError);
       input.value = '';
     }
-    this.setState({ pomosEstimated: 0});
+    this.setState({ pomosEstimated: 0 });
   }
 
   focusTodoInput() {

--- a/imports/ui/components/ListHeader.less
+++ b/imports/ui/components/ListHeader.less
@@ -2,7 +2,7 @@
 
 .list-header {
   background: linear-gradient(to bottom, #d0edf5, #e1e5f0 100%);
-  height: 5em;
+  height: 7em;
 
   text-align: center;
   @media screen and (min-width: 40em) { text-align: left; }
@@ -41,7 +41,7 @@
       vertical-align: middle;
     }
   }
-  form.todo-new {
+  .todo-new {
     .position(absolute, 3em, 0, auto, 0);
 
     input[type="text"] {
@@ -51,7 +51,7 @@
       padding-top: .25em;
     }
   }
-  form.list-edit-form {
+  .list-edit-form {
     position: relative;
 
     input[type="text"] {
@@ -60,6 +60,24 @@
       width: 100%;
       padding-right: 3em;
       padding-left: 1rem;
+    }
+  }
+
+  .pomo-estimate-dropdown{
+    .position(absolute, 5em, 0, 0, 0);
+    height: 2em;
+    .form-control{
+      padding-left: 44px !important;
+      border:none;
+      border-radius: 0;
+      -webkit-appearance: none;
+      background: transparent;
+    }
+    .icon-arrow-down {
+      pointer-events: none;
+    }
+    .default-option{
+      color: red;
     }
   }
 

--- a/imports/ui/components/PomoTimer.jsx
+++ b/imports/ui/components/PomoTimer.jsx
@@ -1,0 +1,30 @@
+import React, { Component, PropTypes } from 'react'
+import BaseComponent from './BaseComponent.jsx';
+
+
+// Component
+export default class Task extends BaseComponent {
+
+   render() {
+
+      return (
+        <div>
+          <label>Pomodoro Timer</label>
+          <div>
+              <h2>HH:MM:SS</h2>
+          </div>
+          <div>
+              <button type="button" className="btn btn-primary btn-md">START/STOP</button>
+          </div>
+          <div>
+              ToDo Item Selected
+          </div>
+        </div>
+        
+      )
+   }
+}
+
+Task.propTypes = {
+}
+

--- a/imports/ui/components/PomoTimer.jsx
+++ b/imports/ui/components/PomoTimer.jsx
@@ -1,30 +1,23 @@
-import React, { Component, PropTypes } from 'react'
+import React from 'react';
 import BaseComponent from './BaseComponent.jsx';
 
 
-// Component
 export default class Task extends BaseComponent {
 
-   render() {
-
-      return (
+  render() {
+    return (
+      <div>
+        <h2>Pomodoro Timer</h2>
         <div>
-          <label>Pomodoro Timer</label>
-          <div>
-              <h2>HH:MM:SS</h2>
-          </div>
-          <div>
-              <button type="button" className="btn btn-primary btn-md">START/STOP</button>
-          </div>
-          <div>
-              ToDo Item Selected
-          </div>
+          <h2>HH:MM:SS</h2>
         </div>
-        
-      )
-   }
+        <div>
+          <button type="button" className="btn btn-primary btn-md">START/STOP</button>
+        </div>
+        <div>
+          ToDo Item Selected
+        </div>
+      </div>
+    );
+  }
 }
-
-Task.propTypes = {
-}
-

--- a/imports/ui/components/PomoTimer.jsx
+++ b/imports/ui/components/PomoTimer.jsx
@@ -1,21 +1,114 @@
-import React from 'react';
-import BaseComponent from './BaseComponent.jsx';
+import React, { Component } from 'react';
 
+export default class PomoTimer extends Component {
+  constructor(props) {
+    super(props);
 
-export default class Task extends BaseComponent {
+    // Set time remaining from local storage (in case of page-refresh).
+    // Otherwise default time is 25 minutes (calculated in milliseconds)
+    // let timeRemaining = localStorage.timeRemaining? localStorage.timeRemaining : 25 * 60 * 1000;
+    // let timeRemaining = 25 * 60 * 1000;
+    const timeRemaining = 2 * 1000;
+
+    this.state = {
+      minutes: 25,
+      seconds: 0,
+      beepRunning: false,
+      beeps: 0,
+      timeRunning: false,
+      timeRemaining,
+    };
+
+    this.startTimer = this.startTimer.bind(this);
+    this.stopTimer = this.stopTimer.bind(this);
+  }
+
+  countDownASecond() {
+    let timeRemaining = this.state.timeRemaining;
+
+    timeRemaining = (timeRemaining < 1) ? 0 : timeRemaining - 1000;
+
+    // Play warning beep to user
+    if (timeRemaining < 1 && !this.state.beepRunning) {
+      this.setState({ beepRunning: true });
+      this.intervalIDBeep = setInterval(this.beep.bind(this), 1000);
+      // this.intervalIDBeep = setInterval(this.beep.bind(this), 500);
+    }
+
+    const minutes = Math.floor((timeRemaining / 1000 / 60) % 60);
+    const seconds = Math.floor((timeRemaining / 1000) % 60);
+
+    this.setState({
+      timeRemaining,
+      minutes,
+      seconds,
+    });
+
+    // this.localStorage.timeRemaining = timeRemaining;
+  }
+
+  beep() {
+    const sound = new Audio('data:audio/wav;base64,//uQRAAAAWMSLwUIYAAsYkXgoQwAEaYLWfkWgAI0wWs/ItAAAGDgYtAgAyN+QWaAAihwMWm4G8QQRDiMcCBcH3Cc+CDv/7xA4Tvh9Rz/y8QADBwMWgQAZG/ILNAARQ4GLTcDeIIIhxGOBAuD7hOfBB3/94gcJ3w+o5/5eIAIAAAVwWgQAVQ2ORaIQwEMAJiDg95G4nQL7mQVWI6GwRcfsZAcsKkJvxgxEjzFUgfHoSQ9Qq7KNwqHwuB13MA4a1q/DmBrHgPcmjiGoh//EwC5nGPEmS4RcfkVKOhJf+WOgoxJclFz3kgn//dBA+ya1GhurNn8zb//9NNutNuhz31f////9vt///z+IdAEAAAK4LQIAKobHItEIYCGAExBwe8jcToF9zIKrEdDYIuP2MgOWFSE34wYiR5iqQPj0JIeoVdlG4VD4XA67mAcNa1fhzA1jwHuTRxDUQ//iYBczjHiTJcIuPyKlHQkv/LHQUYkuSi57yQT//uggfZNajQ3Vmz+Zt//+mm3Wm3Q576v////+32///5/EOgAAADVghQAAAAA//uQZAUAB1WI0PZugAAAAAoQwAAAEk3nRd2qAAAAACiDgAAAAAAABCqEEQRLCgwpBGMlJkIz8jKhGvj4k6jzRnqasNKIeoh5gI7BJaC1A1AoNBjJgbyApVS4IDlZgDU5WUAxEKDNmmALHzZp0Fkz1FMTmGFl1FMEyodIavcCAUHDWrKAIA4aa2oCgILEBupZgHvAhEBcZ6joQBxS76AgccrFlczBvKLC0QI2cBoCFvfTDAo7eoOQInqDPBtvrDEZBNYN5xwNwxQRfw8ZQ5wQVLvO8OYU+mHvFLlDh05Mdg7BT6YrRPpCBznMB2r//xKJjyyOh+cImr2/4doscwD6neZjuZR4AgAABYAAAABy1xcdQtxYBYYZdifkUDgzzXaXn98Z0oi9ILU5mBjFANmRwlVJ3/6jYDAmxaiDG3/6xjQQCCKkRb/6kg/wW+kSJ5//rLobkLSiKmqP/0ikJuDaSaSf/6JiLYLEYnW/+kXg1WRVJL/9EmQ1YZIsv/6Qzwy5qk7/+tEU0nkls3/zIUMPKNX/6yZLf+kFgAfgGyLFAUwY//uQZAUABcd5UiNPVXAAAApAAAAAE0VZQKw9ISAAACgAAAAAVQIygIElVrFkBS+Jhi+EAuu+lKAkYUEIsmEAEoMeDmCETMvfSHTGkF5RWH7kz/ESHWPAq/kcCRhqBtMdokPdM7vil7RG98A2sc7zO6ZvTdM7pmOUAZTnJW+NXxqmd41dqJ6mLTXxrPpnV8avaIf5SvL7pndPvPpndJR9Kuu8fePvuiuhorgWjp7Mf/PRjxcFCPDkW31srioCExivv9lcwKEaHsf/7ow2Fl1T/9RkXgEhYElAoCLFtMArxwivDJJ+bR1HTKJdlEoTELCIqgEwVGSQ+hIm0NbK8WXcTEI0UPoa2NbG4y2K00JEWbZavJXkYaqo9CRHS55FcZTjKEk3NKoCYUnSQ0rWxrZbFKbKIhOKPZe1cJKzZSaQrIyULHDZmV5K4xySsDRKWOruanGtjLJXFEmwaIbDLX0hIPBUQPVFVkQkDoUNfSoDgQGKPekoxeGzA4DUvnn4bxzcZrtJyipKfPNy5w+9lnXwgqsiyHNeSVpemw4bWb9psYeq//uQZBoABQt4yMVxYAIAAAkQoAAAHvYpL5m6AAgAACXDAAAAD59jblTirQe9upFsmZbpMudy7Lz1X1DYsxOOSWpfPqNX2WqktK0DMvuGwlbNj44TleLPQ+Gsfb+GOWOKJoIrWb3cIMeeON6lz2umTqMXV8Mj30yWPpjoSa9ujK8SyeJP5y5mOW1D6hvLepeveEAEDo0mgCRClOEgANv3B9a6fikgUSu/DmAMATrGx7nng5p5iimPNZsfQLYB2sDLIkzRKZOHGAaUyDcpFBSLG9MCQALgAIgQs2YunOszLSAyQYPVC2YdGGeHD2dTdJk1pAHGAWDjnkcLKFymS3RQZTInzySoBwMG0QueC3gMsCEYxUqlrcxK6k1LQQcsmyYeQPdC2YfuGPASCBkcVMQQqpVJshui1tkXQJQV0OXGAZMXSOEEBRirXbVRQW7ugq7IM7rPWSZyDlM3IuNEkxzCOJ0ny2ThNkyRai1b6ev//3dzNGzNb//4uAvHT5sURcZCFcuKLhOFs8mLAAEAt4UWAAIABAAAAAB4qbHo0tIjVkUU//uQZAwABfSFz3ZqQAAAAAngwAAAE1HjMp2qAAAAACZDgAAAD5UkTE1UgZEUExqYynN1qZvqIOREEFmBcJQkwdxiFtw0qEOkGYfRDifBui9MQg4QAHAqWtAWHoCxu1Yf4VfWLPIM2mHDFsbQEVGwyqQoQcwnfHeIkNt9YnkiaS1oizycqJrx4KOQjahZxWbcZgztj2c49nKmkId44S71j0c8eV9yDK6uPRzx5X18eDvjvQ6yKo9ZSS6l//8elePK/Lf//IInrOF/FvDoADYAGBMGb7FtErm5MXMlmPAJQVgWta7Zx2go+8xJ0UiCb8LHHdftWyLJE0QIAIsI+UbXu67dZMjmgDGCGl1H+vpF4NSDckSIkk7Vd+sxEhBQMRU8j/12UIRhzSaUdQ+rQU5kGeFxm+hb1oh6pWWmv3uvmReDl0UnvtapVaIzo1jZbf/pD6ElLqSX+rUmOQNpJFa/r+sa4e/pBlAABoAAAAA3CUgShLdGIxsY7AUABPRrgCABdDuQ5GC7DqPQCgbbJUAoRSUj+NIEig0YfyWUho1VBBBA//uQZB4ABZx5zfMakeAAAAmwAAAAF5F3P0w9GtAAACfAAAAAwLhMDmAYWMgVEG1U0FIGCBgXBXAtfMH10000EEEEEECUBYln03TTTdNBDZopopYvrTTdNa325mImNg3TTPV9q3pmY0xoO6bv3r00y+IDGid/9aaaZTGMuj9mpu9Mpio1dXrr5HERTZSmqU36A3CumzN/9Robv/Xx4v9ijkSRSNLQhAWumap82WRSBUqXStV/YcS+XVLnSS+WLDroqArFkMEsAS+eWmrUzrO0oEmE40RlMZ5+ODIkAyKAGUwZ3mVKmcamcJnMW26MRPgUw6j+LkhyHGVGYjSUUKNpuJUQoOIAyDvEyG8S5yfK6dhZc0Tx1KI/gviKL6qvvFs1+bWtaz58uUNnryq6kt5RzOCkPWlVqVX2a/EEBUdU1KrXLf40GoiiFXK///qpoiDXrOgqDR38JB0bw7SoL+ZB9o1RCkQjQ2CBYZKd/+VJxZRRZlqSkKiws0WFxUyCwsKiMy7hUVFhIaCrNQsKkTIsLivwKKigsj8XYlwt/WKi2N4d//uQRCSAAjURNIHpMZBGYiaQPSYyAAABLAAAAAAAACWAAAAApUF/Mg+0aohSIRobBAsMlO//Kk4soosy1JSFRYWaLC4qZBYWFRGZdwqKiwkNBVmoWFSJkWFxX4FFRQWR+LsS4W/rFRb/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////VEFHAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAU291bmRib3kuZGUAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMjAwNGh0dHA6Ly93d3cuc291bmRib3kuZGUAAAAAAAAAACU=');
+    if (this.state.beeps > 5) {
+      sound.pause();
+    } else {
+      sound.play();
+      this.setState({ beeps: this.state.beeps + 1 });
+    }
+  }
+
+  startTimer() {
+    this.setState({ timeRunning: true });
+    this.intervalIDTimer = setInterval(this.countDownASecond.bind(this), 1000);
+  }
+
+  stopTimer() {
+    clearInterval(this.intervalIDTimer);
+    clearInterval(this.intervalIDBeep);
+    const timeRemaining = 25 * 60 * 1000;
+
+    this.setState({
+      timeRunning: false,
+      beepRunning: false,
+      beeps: 0,
+      timeRemaining,
+    });
+    // this.localStorage.timeRemaining = timeRemaining;
+  }
 
   render() {
     return (
-      <div>
-        <h2>Pomodoro Timer</h2>
+      <div className="pomo-timer">
+        <br />
+        <br />
         <div>
-          <h2>HH:MM:SS</h2>
+          ToDo Item Selected:
+        </div>
+        <div>Time until break:</div>
+        <div className="timer">
+          <h2 className={(this.state.timeRemaining < 1) ? 'text-blink' : ''}>
+            {(this.state.minutes < 10) ? (`0${this.state.minutes}`) : this.state.minutes }
+            :
+            {(this.state.seconds < 10) ? (`0${this.state.seconds}`) : this.state.seconds }
+          </h2>
         </div>
         <div>
-          <button type="button" className="btn btn-primary btn-md">START/STOP</button>
-        </div>
-        <div>
-          ToDo Item Selected
+          { !this.state.timeRunning ?
+            <button
+              type="button"
+              className="btn btn-primary btn-md"
+              onClick={this.startTimer}
+            >
+              START
+              </button> :
+            <button
+              type="button"
+              className="btn btn-danger btn-md"
+              onClick={this.stopTimer}
+            >
+              STOP
+              </button>
+          }
         </div>
       </div>
     );

--- a/imports/ui/components/PomoTimer.jsx
+++ b/imports/ui/components/PomoTimer.jsx
@@ -1,5 +1,9 @@
 import React, { Component } from 'react';
 
+import {
+  pomosCompletedPlusPlus,
+} from '../../api/todos/methods.js';
+
 export default class PomoTimer extends Component {
   constructor(props) {
     super(props);
@@ -13,7 +17,6 @@ export default class PomoTimer extends Component {
       seconds: 0,
       beepRunning: false,
       beeps: 0,
-      timeRunning: false,
       timeRemaining: 25 * 60 * 1000,
     };
 
@@ -60,9 +63,10 @@ export default class PomoTimer extends Component {
     // const timeRemaining = 25 * 60 * 1000;
     const timeRemaining = 11 * 1000;
     this.setState({
-      timeRunning: true,
       timeRemaining,
     });
+    this.props.toggleTimeRunning();
+
     // Clear Break timer and start pomodoro timer
     clearInterval(this.intervalIDTimer);
     this.intervalIDTimer = setInterval(this.countDownASecond.bind(this), 1000);
@@ -76,14 +80,22 @@ export default class PomoTimer extends Component {
     const timeRemaining = breakTime;
 
     this.setState({
-      timeRunning: false,
       beepRunning: false,
       beeps: 0,
       timeRemaining,
     });
 
+    this.props.toggleTimeRunning();
+
     // Start break timer
     this.intervalIDTimer = setInterval(this.countDownASecond.bind(this), 1000);
+
+    // increment pomosCompleted only if the timer actually finished and a todo was selected
+    if (this.state.timeRemaining < 1 && this.props.todoID) {
+      pomosCompletedPlusPlus.call({
+        todoId: this.props.todoID,
+      });
+    }
   }
 
   render() {
@@ -100,7 +112,7 @@ export default class PomoTimer extends Component {
           </h2>
         </div>
         <div>
-          {!this.state.timeRunning ?
+          {!this.props.timeRunning ?
             <button
               type="button"
               className="btn btn-primary btn-md"
@@ -121,3 +133,10 @@ export default class PomoTimer extends Component {
     );
   }
 }
+
+PomoTimer.propTypes = {
+  todoID: React.PropTypes.string,
+  timeRunning: React.PropTypes.bool,
+
+  toggleTimeRunning: React.PropTypes.func,
+};

--- a/imports/ui/components/PomoTimer.jsx
+++ b/imports/ui/components/PomoTimer.jsx
@@ -4,11 +4,9 @@ export default class PomoTimer extends Component {
   constructor(props) {
     super(props);
 
-    // Set time remaining from local storage (in case of page-refresh).
-    // Otherwise default time is 25 minutes (calculated in milliseconds)
-    // let timeRemaining = localStorage.timeRemaining? localStorage.timeRemaining : 25 * 60 * 1000;
-    // let timeRemaining = 25 * 60 * 1000;
-    const timeRemaining = 2 * 1000;
+    // Get timer from local storage or set default timer
+    // let timeRemaining = localStorage.getItem('timeRemaining');
+    // timeRemaining = timeRemaining || 25 * 60 * 1000;
 
     this.state = {
       minutes: 25,
@@ -16,7 +14,7 @@ export default class PomoTimer extends Component {
       beepRunning: false,
       beeps: 0,
       timeRunning: false,
-      timeRemaining,
+      timeRemaining: 25 * 60 * 1000,
     };
 
     this.startTimer = this.startTimer.bind(this);
@@ -32,7 +30,6 @@ export default class PomoTimer extends Component {
     if (timeRemaining < 1 && !this.state.beepRunning) {
       this.setState({ beepRunning: true });
       this.intervalIDBeep = setInterval(this.beep.bind(this), 1000);
-      // this.intervalIDBeep = setInterval(this.beep.bind(this), 500);
     }
 
     const minutes = Math.floor((timeRemaining / 1000 / 60) % 60);
@@ -44,7 +41,7 @@ export default class PomoTimer extends Component {
       seconds,
     });
 
-    // this.localStorage.timeRemaining = timeRemaining;
+    // localStorage.setItem('timeRemaining', timeRemaining);
   }
 
   beep() {
@@ -58,14 +55,25 @@ export default class PomoTimer extends Component {
   }
 
   startTimer() {
-    this.setState({ timeRunning: true });
+    // Set time remaining from local storage (in case of page-refresh).
+    // Otherwise default time is 25 minutes (calculated in milliseconds)
+    // const timeRemaining = 25 * 60 * 1000;
+    const timeRemaining = 11 * 1000;
+    this.setState({
+      timeRunning: true,
+      timeRemaining,
+    });
+    // Clear Break timer and start pomodoro timer
+    clearInterval(this.intervalIDTimer);
     this.intervalIDTimer = setInterval(this.countDownASecond.bind(this), 1000);
   }
 
   stopTimer() {
+    // Clear pomo timer
     clearInterval(this.intervalIDTimer);
     clearInterval(this.intervalIDBeep);
-    const timeRemaining = 25 * 60 * 1000;
+    const breakTime = 5 * 60 * 1000;
+    const timeRemaining = breakTime;
 
     this.setState({
       timeRunning: false,
@@ -73,7 +81,9 @@ export default class PomoTimer extends Component {
       beeps: 0,
       timeRemaining,
     });
-    // this.localStorage.timeRemaining = timeRemaining;
+
+    // Start break timer
+    this.intervalIDTimer = setInterval(this.countDownASecond.bind(this), 1000);
   }
 
   render() {
@@ -81,19 +91,16 @@ export default class PomoTimer extends Component {
       <div className="pomo-timer">
         <br />
         <br />
-        <div>
-          ToDo Item Selected:
-        </div>
-        <div>Time until break:</div>
+        <div>Time Remaining:</div>
         <div className="timer">
           <h2 className={(this.state.timeRemaining < 1) ? 'text-blink' : ''}>
-            {(this.state.minutes < 10) ? (`0${this.state.minutes}`) : this.state.minutes }
+            {(this.state.minutes < 10) ? (`0${this.state.minutes}`) : this.state.minutes}
             :
-            {(this.state.seconds < 10) ? (`0${this.state.seconds}`) : this.state.seconds }
+            {(this.state.seconds < 10) ? (`0${this.state.seconds}`) : this.state.seconds}
           </h2>
         </div>
         <div>
-          { !this.state.timeRunning ?
+          {!this.state.timeRunning ?
             <button
               type="button"
               className="btn btn-primary btn-md"

--- a/imports/ui/components/PomoTimer.less
+++ b/imports/ui/components/PomoTimer.less
@@ -1,0 +1,1 @@
+@import '{}/imports/ui/stylesheets/utils.less';

--- a/imports/ui/components/PomoTimer.less
+++ b/imports/ui/components/PomoTimer.less
@@ -1,1 +1,18 @@
 @import '{}/imports/ui/stylesheets/utils.less';
+
+.pomo-timer {
+  color: @color-primary; 
+  padding-left: 40px;
+}
+
+.text-blink {
+  animation: blinker 1s linear infinite;
+}
+
+@keyframes blinker {  
+  50% { opacity: 0; }
+}
+
+.timer {
+  margin-bottom: 5px;
+}

--- a/imports/ui/components/TodoItem.jsx
+++ b/imports/ui/components/TodoItem.jsx
@@ -9,6 +9,8 @@ import {
   setCheckedStatus,
   updateText,
   remove,
+  updatePomosEstimated,
+  updatePomosCompleted,
 } from '../../api/todos/methods.js';
 
 export default class TodoItem extends BaseComponent {

--- a/imports/ui/components/TodoItem.jsx
+++ b/imports/ui/components/TodoItem.jsx
@@ -75,6 +75,29 @@ export default class TodoItem extends BaseComponent {
         </label>
         <input
 
+          className="pomo-input"
+          type="number"
+          name="pomosCompleted"
+          placeholder={todo.pomosCompleted ? todo.pomosCompleted : '0'}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
+          onChange={this.updatePomosCompleted}
+          min="0"
+        />
+        <div className="pomo-spacer">of</div>
+        <input
+
+          className="pomo-input"
+          type="number"
+          name="pomosEstimated"
+          placeholder={todo.pomosEstimated ? todo.pomosEstimated : '0'}
+          onFocus={this.onFocus}
+          onBlur={this.onBlur}
+          onChange={this.updatePomosEstimated}
+          min="0"
+        />
+        <input
+
           type="text"
           defaultValue={todo.text}
           placeholder={i18n.__('components.todoItem.taskName')}

--- a/imports/ui/components/TodoItem.jsx
+++ b/imports/ui/components/TodoItem.jsx
@@ -30,6 +30,8 @@ export default class TodoItem extends BaseComponent {
     this.deleteTodo = this.deleteTodo.bind(this);
     this.onFocus = this.onFocus.bind(this);
     this.onBlur = this.onBlur.bind(this);
+    this.updatePomosCompleted = this.updatePomosCompleted.bind(this);
+    this.updatePomosEstimated = this.updatePomosEstimated.bind(this);
   }
 
   onFocus() {
@@ -44,6 +46,20 @@ export default class TodoItem extends BaseComponent {
     setCheckedStatus.call({
       todoId: this.props.todo._id,
       newCheckedStatus: event.target.checked,
+    });
+  }
+
+  updatePomosCompleted(event) {
+    updatePomosCompleted.call({
+      todoId: this.props.todo._id,
+      newNumber: Number(event.target.value),
+    });
+  }
+
+  updatePomosEstimated(event) {
+    updatePomosEstimated.call({
+      todoId: this.props.todo._id,
+      newNumber: Number(event.target.value),
     });
   }
 
@@ -80,11 +96,11 @@ export default class TodoItem extends BaseComponent {
           className="pomo-input"
           type="number"
           name="pomosCompleted"
+          defaultValue={todo.pomosCompleted ? todo.pomosCompleted : '0'}
           placeholder={todo.pomosCompleted ? todo.pomosCompleted : '0'}
-          onFocus={this.onFocus}
-          onBlur={this.onBlur}
-          onChange={this.updatePomosCompleted}
+          onBlur={this.updatePomosCompleted}
           min="0"
+          max="99"
         />
         <div className="pomo-spacer">of</div>
         <input
@@ -92,11 +108,11 @@ export default class TodoItem extends BaseComponent {
           className="pomo-input"
           type="number"
           name="pomosEstimated"
+          defaultValue={todo.pomosEstimated ? todo.pomosEstimated : '0'}
           placeholder={todo.pomosEstimated ? todo.pomosEstimated : '0'}
-          onFocus={this.onFocus}
-          onBlur={this.onBlur}
-          onChange={this.updatePomosEstimated}
+          onBlur={this.updatePomosEstimated}
           min="0"
+          max="99"
         />
         <input
 

--- a/imports/ui/components/TodoItem.jsx
+++ b/imports/ui/components/TodoItem.jsx
@@ -32,6 +32,7 @@ export default class TodoItem extends BaseComponent {
     this.onBlur = this.onBlur.bind(this);
     this.updatePomosCompleted = this.updatePomosCompleted.bind(this);
     this.updatePomosEstimated = this.updatePomosEstimated.bind(this);
+    this.startTimer = this.startTimer.bind(this);
   }
 
   onFocus() {
@@ -47,6 +48,10 @@ export default class TodoItem extends BaseComponent {
       todoId: this.props.todo._id,
       newCheckedStatus: event.target.checked,
     });
+  }
+
+  startTimer() {
+    this.props.startTimer(this.props.todo._id);
   }
 
   updatePomosCompleted(event) {
@@ -91,17 +96,19 @@ export default class TodoItem extends BaseComponent {
           />
           <span className="checkbox-custom" />
         </label>
-        <input
-
-          className="pomo-input"
-          type="number"
-          name="pomosCompleted"
-          defaultValue={todo.pomosCompleted ? todo.pomosCompleted : '0'}
-          placeholder={todo.pomosCompleted ? todo.pomosCompleted : '0'}
-          onBlur={this.updatePomosCompleted}
-          min="0"
-          max="99"
-        />
+        { !this.props.timeRunning ?
+          <input
+            className="pomo-input"
+            type="number"
+            name="pomosCompleted"
+            defaultValue={todo.pomosCompleted ? todo.pomosCompleted : '0'}
+            placeholder={todo.pomosCompleted ? todo.pomosCompleted : '0'}
+            onBlur={this.updatePomosCompleted}
+            min="0"
+            max="99"
+          /> :
+          <div className="static-pomo" >{todo.pomosCompleted ? todo.pomosCompleted : '0'}</div>
+        }
         <div className="pomo-spacer">of</div>
         <input
 
@@ -123,14 +130,29 @@ export default class TodoItem extends BaseComponent {
           onBlur={this.onBlur}
           onChange={this.updateTodo}
         />
-        <a
-          className="delete-item"
-          href="#delete"
-          onClick={this.deleteTodo}
-          onMouseDown={this.deleteTodo}
-        >
-          <span className="icon-trash" />
-        </a>
+        {!this.props.timeRunning ?
+          <a
+            className="delete-item"
+            href="#delete"
+            onClick={this.deleteTodo}
+            onMouseDown={this.deleteTodo}
+          >
+            <span className="icon-trash" />
+          </a> :
+          ''
+        }
+
+        {!this.props.timeRunning ?
+          <button
+            type="button"
+            className="btn btn-primary btn-sm custom-button"
+            onClick={this.startTimer}
+          >
+            START
+            </button> :
+            ''
+        }
+
       </div>
     );
   }
@@ -140,4 +162,5 @@ TodoItem.propTypes = {
   todo: React.PropTypes.object,
   editing: React.PropTypes.bool,
   onEditingChange: React.PropTypes.func,
+  startTimer: React.PropTypes.func,
 };

--- a/imports/ui/components/TodoItem.less
+++ b/imports/ui/components/TodoItem.less
@@ -15,6 +15,19 @@
     cursor: pointer;
   }
 
+  .custom-button {
+    margin-right: 8px;
+  }
+
+  .static-pomo {
+    width: 40px;
+    padding-top: 1px;
+    padding-bottom: 1px;
+    padding-right: 5px;
+    text-align: center;
+    color: @color-well;
+  }
+
   .pomo-input {
     width: 40px;
     height: 1rem;
@@ -97,6 +110,9 @@
       }
     }
     .pomo-spacer{
+      color: @color-medium-rare;
+    }
+    .static-pomo{
       color: @color-medium-rare;
     }
 

--- a/imports/ui/components/TodoItem.less
+++ b/imports/ui/components/TodoItem.less
@@ -5,16 +5,27 @@
 
   // Layout of list-item children
   display: flex;
+  justify-content: flex-start;
   flex-wrap: wrap;
   height: 3rem;
-  width: 100%;
+  align-items: center;
 
   .checkbox {
-    flex: 0, 0, 44px;
+    height: 1rem;
     cursor: pointer;
   }
+
+  .pomo-input {
+    width: 40px;
+    height: 1rem;
+    border: none;
+    padding-left: 10px;
+    text-align: center;
+    color: @color-well;
+  }
+
   input[type="text"] { flex: 1; }
-  .delete-item { flex: 0 0 3rem; }
+  .delete-item { flex: 0 0 1rem; }
 
 
   // Style of list-item children
@@ -27,8 +38,9 @@
 
   .delete-item {
     color: @color-medium-rare;
-    line-height: 3rem;
-    text-align: center;
+    display: flex;
+    justify-content: flex-end;
+    margin: 0 auto;
 
     &:hover { color: @color-primary; }
     &:active { color: @color-well; }
@@ -45,11 +57,23 @@
       color: @color-medium-rare;
       text-decoration: line-through;
     }
+    .pomo-input{
+      color: @color-medium-rare;
+    }
+    .pomo-spacer{
+      color: @color-medium-rare;
+    }
 
-    .delete-item { display: inline-block; }
+    .delete-item {
+       display: flex;
+       padding-right: 15px;
+    }
   }
 
   // Editing
   .delete-item { display: none; }
-  &.editing .delete-item { display: inline-block; }
+  &.editing .delete-item {
+     display: flex;
+     padding-right: 15px;
+  }
 }

--- a/imports/ui/components/TodoItem.less
+++ b/imports/ui/components/TodoItem.less
@@ -21,7 +21,25 @@
     border: none;
     padding-left: 10px;
     text-align: center;
-    color: @color-well;
+
+    // Change placeholder text color on pomo inputs
+    &::-webkit-input-placeholder { /* WebKit, Blink, Edge */
+      color:    @color-well;
+    }
+    &::-moz-placeholder { /* Mozilla Firefox 4 to 18 */
+      color:    @color-well;
+      opacity:  1;
+    }
+    &::-moz-placeholder { /* Mozilla Firefox 19+ */
+      color:    @color-well;
+      opacity:  1;
+    }
+    &:-ms-input-placeholder { /* Internet Explorer 10-11 */
+      color:    @color-well;
+    }
+    &::-ms-input-placeholder { /* Microsoft Edge */
+      color:    @color-well;
+    }
   }
 
   input[type="text"] { flex: 1; }
@@ -59,6 +77,24 @@
     }
     .pomo-input{
       color: @color-medium-rare;
+      // Change placeholder text color on pomo inputs
+      &::-webkit-input-placeholder { /* WebKit, Blink, Edge */
+        color:    @color-medium-rare;
+      }
+      &::-moz-placeholder { /* Mozilla Firefox 4 to 18 */
+        color:    @color-medium-rare;
+        opacity:  1;
+      }
+      &::-moz-placeholder { /* Mozilla Firefox 19+ */
+        color:    @color-medium-rare;
+        opacity:  1;
+      }
+      &:-ms-input-placeholder { /* Internet Explorer 10-11 */
+        color:    @color-medium-rare;
+      }
+      &::-ms-input-placeholder { /* Microsoft Edge */
+        color:    @color-medium-rare;
+      }
     }
     .pomo-spacer{
       color: @color-medium-rare;

--- a/imports/ui/components/UserMenu.less
+++ b/imports/ui/components/UserMenu.less
@@ -9,6 +9,7 @@
     padding-top: .5em;
     padding-bottom: .5em;
     width: 110px;
+    color: @color-ancillary;
   }
 
   &.vertical .btn-secondary {

--- a/imports/ui/containers/ListPageContainer.jsx
+++ b/imports/ui/containers/ListPageContainer.jsx
@@ -3,16 +3,19 @@ import { createContainer } from 'meteor/react-meteor-data';
 import { Lists } from '../../api/lists/lists.js';
 import ListPage from '../pages/ListPage.jsx';
 
-const ListPageContainer = createContainer(({ params: { id } }) => {
+const ListPageContainer = createContainer(({ params: { id }, startTimer, timeRunning }) => {
   const todosHandle = Meteor.subscribe('todos.inList', { listId: id });
   const loading = !todosHandle.ready();
   const list = Lists.findOne(id);
   const listExists = !loading && !!list;
+
   return {
     loading,
     list,
     listExists,
     todos: listExists ? list.todos().fetch() : [],
+    startTimer,
+    timeRunning,
   };
 }, ListPage);
 

--- a/imports/ui/layouts/App.jsx
+++ b/imports/ui/layouts/App.jsx
@@ -5,6 +5,7 @@ import { Session } from 'meteor/session'; // XXX: SESSION
 import { Lists } from '../../api/lists/lists.js';
 import UserMenu from '../components/UserMenu.jsx';
 import ListList from '../components/ListList.jsx';
+import PomoTimer from '../components/PomoTimer.jsx';
 import LanguageToggle from '../components/LanguageToggle.jsx';
 import ConnectionNotification from '../components/ConnectionNotification.jsx';
 import Loading from '../components/Loading.jsx';
@@ -81,6 +82,7 @@ export default class App extends React.Component {
           <LanguageToggle />
           <UserMenu user={user} logout={this.logout} />
           <ListList lists={lists} />
+          <PomoTimer />
         </section>
         {showConnectionIssue && !connected
           ? <ConnectionNotification />

--- a/imports/ui/layouts/App.jsx
+++ b/imports/ui/layouts/App.jsx
@@ -18,9 +18,13 @@ export default class App extends React.Component {
     this.state = {
       menuOpen: false,
       showConnectionIssue: false,
+      todoPomoID: undefined,
+      timeRunning: false,
     };
     this.toggleMenu = this.toggleMenu.bind(this);
     this.logout = this.logout.bind(this);
+    this.startTimer = this.startTimer.bind(this);
+    this.toggleTimeRunning = this.toggleTimeRunning.bind(this);
   }
 
   componentDidMount() {
@@ -36,6 +40,15 @@ export default class App extends React.Component {
       const list = Lists.findOne();
       this.context.router.replace(`/lists/${list._id}`);
     }
+  }
+
+  toggleTimeRunning() {
+    this.setState({ timeRunning: !this.state.timeRunning });
+  }
+
+  startTimer(id) {
+    this.setState({ todoPomoID: id });
+    this.pomoTimer.startTimer();
   }
 
   toggleMenu(menuOpen = !Session.get('menuOpen')) {
@@ -74,6 +87,8 @@ export default class App extends React.Component {
     // have transitions
     const clonedChildren = children && React.cloneElement(children, {
       key: location.pathname,
+      startTimer: this.startTimer,
+      timeRunning: this.state.timeRunning,
     });
 
     return (
@@ -82,7 +97,12 @@ export default class App extends React.Component {
           <LanguageToggle />
           <UserMenu user={user} logout={this.logout} />
           <ListList lists={lists} />
-          <PomoTimer />
+          <PomoTimer
+            ref={(c) => { this.pomoTimer = c; }}
+            todoID={this.state.todoPomoID}
+            timeRunning={this.state.timeRunning}
+            toggleTimeRunning={this.toggleTimeRunning}
+          />
         </section>
         {showConnectionIssue && !connected
           ? <ConnectionNotification />

--- a/imports/ui/pages/ListPage.jsx
+++ b/imports/ui/pages/ListPage.jsx
@@ -20,7 +20,7 @@ export default class ListPage extends BaseComponent {
   }
 
   render() {
-    const { list, listExists, loading, todos } = this.props;
+    const { list, listExists, loading, todos, startTimer, timeRunning } = this.props;
     const { editingTodo } = this.state;
 
     if (!listExists) {
@@ -42,6 +42,8 @@ export default class ListPage extends BaseComponent {
           key={todo._id}
           editing={todo._id === editingTodo}
           onEditingChange={this.onEditingChange}
+          startTimer={startTimer}
+          timeRunning={timeRunning}
         />
       ));
     }

--- a/imports/ui/pages/ListPage.less
+++ b/imports/ui/pages/ListPage.less
@@ -3,6 +3,6 @@
 .page.lists-show {
   .content-scrollable {
     background: @color-empty;
-    top: 5em !important;
+    top: 7em !important;
   }
 }


### PR DESCRIPTION
Hi Mack,

I've been chopping away at this feature. I've created an MVP feature for a pomodoro timer to go along with the todo list. To make it easier for you, instead of 25 minutes and 5 minutes, the timer runs for 11 seconds and 5 minutes. The biggest feature that's missing is to automatically increment the completed pomodoro with a respective todo list item and storing the remaining timer in local storage in case the user refreshes the page.

I'll describe the feature below:
MVP Pomodoro Timer feature!

Workflow:
1) Choose a todo item to work on (mentally note);
2) Hit Start and the timer will count for 25 minutes (11 seconds currently)
3) Work on your task until the timer rings (you will hear a 5 beeps), then checkmark the completed item or increment your list of completed pomodoros next to the todo item
4) Hit Stop and Take a five minute break with the app (you just completed your first Pomodoro!); then

5) Repeat steps 1–4 three more times, followed by a 15 minute break.

